### PR TITLE
Add strokeWidth to Cell component

### DIFF
--- a/src/BsRecharts__Cell.re
+++ b/src/BsRecharts__Cell.re
@@ -2,11 +2,11 @@
 [@bs.module "recharts"] external reactClass: ReasonReact.reactClass = "Cell";
 
 [@bs.obj]
-external makeProps: (~fill: string=?, ~stroke: string=?, unit) => _ = "";
+external makeProps: (~fill: string=?, ~stroke: string=?, ~strokeWidth: int=?, unit) => _ = "";
 
-let make = (~fill=?, ~stroke=?, children) =>
+let make = (~fill=?, ~stroke=?, ~strokeWidth=?, children) =>
   ReasonReact.wrapJsForReason(
     ~reactClass,
-    ~props=makeProps(~fill?, ~stroke?, ()),
+    ~props=makeProps(~fill?, ~stroke?, ~strokeWidth?, ()),
     children,
   );


### PR DESCRIPTION
Although it's not explicitly stated in the API documentation, there is a strokeWidth prop allowed in the Cell component.

You can see it in the second example here: http://recharts.org/en-US/api/Cell

This was a pretty simple addition.