### PR TITLE
compatibility with bs-platform 5.0.0

### DIFF
--- a/src/BsRecharts__Utils.re
+++ b/src/BsRecharts__Utils.re
@@ -64,7 +64,7 @@ module PxOrPrc = {
   let encode: arg => t =
     fun
     | Px(v) => Obj.magic(v)
-    | Prc(v) => Obj.magic(string_of_float(v) ++ "%");
+    | Prc(v) => Obj.magic(Js.Float.toString(v) ++ "%");
   let encodeOpt = Belt.Option.map(_, encode);
 };
 


### PR DESCRIPTION
bs-platform is now available in 5.0.0 version. In this version function: string_of_float is depricated, so when in my project is bs-platfom 5.0.0 and bs-recharts - compiling throws warning that string_of_float is depricated. Its very annoying. I changed it to supported function.

bs-platform release note: https://github.com/BuckleScript/bucklescript/blob/master/Changes.md#500