### PR TITLE
Update recharts to v1.8.5 and bs-platform to v8.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "binding"
   ],
   "devDependencies": {
-    "bs-platform": "^5.0.6",
+    "bs-platform": "^8.2.0",
     "reason-react": ">=0.7.0"
   },
   "peerDependencies": {
     "reason-react": ">=0.7.0",
-    "recharts": "^1.6.2"
+    "recharts": "^1.8.5"
   }
 }

--- a/src/BsRecharts__Area.re
+++ b/src/BsRecharts__Area.re
@@ -3,7 +3,7 @@
 [@bs.module "recharts"] [@react.component]
 external make:
   (
-    ~_type: [@bs.string] [
+    ~_type: [
               | `basis
               | `basisClosed
               | `basisOpen
@@ -39,8 +39,8 @@ external make:
     ~id: string=?,
     ~isAnimationActive: bool=?,
     ~label: 'label=?,
-    ~layout: [@bs.string] [ | `horizontal | `vertical]=?,
-    ~legendType: [@bs.string] [
+    ~layout: [ | `horizontal | `vertical]=?,
+    ~legendType: [
                    | `line
                    | `square
                    | `rect

--- a/src/BsRecharts__AreaChart.re
+++ b/src/BsRecharts__AreaChart.re
@@ -9,13 +9,13 @@ external make:
     ~className: string=?,
     ~data: array('dataItem),
     ~height: int=?,
-    ~layout: [@bs.string] [ | `horizontal | `vertical]=?,
+    ~layout: [ | `horizontal | `vertical]=?,
     ~margin: margin=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
     ~onMouseEnter: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), ReactEvent.Mouse.t) => unit=?,
     ~onMouseMove: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
-    ~stackOffset: [@bs.string] [ | `expand | `none | `wiggle | `silhouette]=?,
+    ~stackOffset: [ | `expand | `none | `wiggle | `silhouette]=?,
     ~syncId: string=?,
     ~width: int=?,
     ~children: React.element
@@ -59,7 +59,9 @@ module Jsx2 = {
         ~stackOffset?,
         ~syncId?,
         ~width?,
-        ~children={React.array(children)},
+        ~children={
+          React.array(children);
+        },
         (),
       ),
       children,

--- a/src/BsRecharts__Bar.re
+++ b/src/BsRecharts__Bar.re
@@ -22,8 +22,8 @@ external make:
     ~id: string=?,
     ~isAnimationActive: bool=?,
     ~label: 'label=?,
-    ~layout: [@bs.string] [ | `horizontal | `vertical]=?,
-    ~legendType: [@bs.string] [
+    ~layout: [ | `horizontal | `vertical]=?,
+    ~legendType: [
                    | `line
                    | `square
                    | `rect

--- a/src/BsRecharts__BarChart.re
+++ b/src/BsRecharts__BarChart.re
@@ -10,7 +10,7 @@ external make:
     ~barSize: int=?,
     ~className: string=?,
     ~height: int=?,
-    ~layout: [@bs.string] [ | `horizontal | `vertical]=?,
+    ~layout: [ | `horizontal | `vertical]=?,
     ~margin: margin=?,
     ~maxBarSize: int=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
@@ -18,14 +18,7 @@ external make:
     ~onMouseLeave: (Js.t({..}), ReactEvent.Mouse.t) => unit=?,
     ~onMouseMove: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
     ~reverseStackOrder: bool=?,
-    ~stackOffset: [@bs.string] [
-                    | `expand
-                    | `none
-                    | `wiggle
-                    | `silhouette
-                    | `sign
-                  ]
-                    =?,
+    ~stackOffset: [ | `expand | `none | `wiggle | `silhouette | `sign]=?,
     ~syncId: string=?,
     ~width: int=?,
     ~children: React.element
@@ -125,7 +118,9 @@ module Jsx2 = {
         ~stackOffset?,
         ~syncId?,
         ~width?,
-        ~children={React.array(children)},
+        ~children={
+          React.array(children);
+        },
         (),
       ),
       children,

--- a/src/BsRecharts__CartesianAxis.re
+++ b/src/BsRecharts__CartesianAxis.re
@@ -11,7 +11,7 @@ external make:
     ~label: 'label=?,
     ~minTickGap: int=?,
     ~mirror: bool=?,
-    ~orientation: [@bs.string] [ | `top | `bottom | `left | `right]=?,
+    ~orientation: [ | `top | `bottom | `left | `right]=?,
     ~tick: 'tick=?,
     ~tickLine: 'tickLine=?,
     ~tickMargin: int,

--- a/src/BsRecharts__ComposedChart.re
+++ b/src/BsRecharts__ComposedChart.re
@@ -10,21 +10,14 @@ external make:
     ~barGap: PxOrPrc.t=?,
     ~barSize: int=?,
     ~height: int=?,
-    ~layout: [@bs.string] [ | `horizontal | `vertical]=?,
+    ~layout: [ | `horizontal | `vertical]=?,
     ~margin: margin=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
     ~onMouseEnter: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
     ~onMouseLeave: (Js.t({..}), ReactEvent.Mouse.t) => unit=?,
     ~onMouseMove: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
     ~reverseStackOrder: bool=?,
-    ~stackOffset: [@bs.string] [
-                    | `expand
-                    | `none
-                    | `wiggle
-                    | `silhouette
-                    | `sign
-                  ]
-                    =?,
+    ~stackOffset: [ | `expand | `none | `wiggle | `silhouette | `sign]=?,
     ~syncId: string=?,
     ~width: int=?,
     ~children: React.element
@@ -120,7 +113,9 @@ module Jsx2 = {
         ~stackOffset?,
         ~syncId?,
         ~width?,
-        ~children={React.array(children)},
+        ~children={
+          React.array(children);
+        },
         (),
       ),
       children,

--- a/src/BsRecharts__Legend.re
+++ b/src/BsRecharts__Legend.re
@@ -4,14 +4,14 @@ open BsRecharts__Utils;
 [@bs.module "recharts"] [@react.component]
 external make:
   (
-    ~align: [@bs.string] [ | `left | `center | `right]=?,
+    ~align: [ | `left | `center | `right]=?,
     ~chartHeight: int=?,
     ~chartWidth: int=?,
     ~content: 'content=?,
     ~className: string=?,
     ~height: int=?,
     ~iconSize: int=?,
-    ~iconType: [@bs.string] [
+    ~iconType: [
                  | `line
                  | `square
                  | `rect
@@ -23,7 +23,7 @@ external make:
                  | `wye
                ]
                  =?,
-    ~layout: [@bs.string] [ | `horizontal | `vertical]=?,
+    ~layout: [ | `horizontal | `vertical]=?,
     ~margin: margin=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
     ~onMouseDown: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
@@ -34,7 +34,7 @@ external make:
     ~onMouseOver: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
     ~onMouseUp: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
     ~payload: array(Js.t({..}))=?,
-    ~verticalAlign: [@bs.string] [ | `top | `middle | `bottom]=?,
+    ~verticalAlign: [ | `top | `middle | `bottom]=?,
     ~width: int=?,
     ~wrapperStyle: Js.t({..})=?
   ) =>

--- a/src/BsRecharts__Line.re
+++ b/src/BsRecharts__Line.re
@@ -3,7 +3,7 @@
 [@bs.module "recharts"] [@react.component]
 external make:
   (
-    ~_type: [@bs.string] [
+    ~_type: [
               | `basis
               | `basisClosed
               | `basisOpen
@@ -36,8 +36,8 @@ external make:
     ~id: string=?,
     ~isAnimationActive: bool=?,
     ~label: 'label=?,
-    ~layout: [@bs.string] [ | `horizontal | `vertical]=?,
-    ~legendType: [@bs.string] [
+    ~layout: [ | `horizontal | `vertical]=?,
+    ~legendType: [
                    | `line
                    | `square
                    | `rect

--- a/src/BsRecharts__LineChart.re
+++ b/src/BsRecharts__LineChart.re
@@ -7,7 +7,7 @@ external make:
     ~className: string=?,
     ~data: array('dataItem),
     ~height: int=?,
-    ~layout: [@bs.string] [ | `horizontal | `vertical]=?,
+    ~layout: [ | `horizontal | `vertical]=?,
     ~margin: margin=?,
     ~onClick: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
     ~onMouseEnter: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
@@ -52,7 +52,9 @@ module Jsx2 = {
         ~onMouseMove?,
         ~syncId?,
         ~width?,
-        ~children={React.array(children)},
+        ~children={
+          React.array(children);
+        },
         (),
       ),
       children,

--- a/src/BsRecharts__Pie.re
+++ b/src/BsRecharts__Pie.re
@@ -28,7 +28,7 @@ external make:
     ~isAnimationActive: bool=?,
     ~label: 'label=?,
     ~labelLine: 'labelLine=?,
-    ~legendType: [@bs.string] [
+    ~legendType: [
                    | `line
                    | `square
                    | `rect
@@ -216,7 +216,9 @@ module Jsx2 = {
         ~paddingAngle?,
         ~startAngle?,
         ~stroke?,
-        ~children={React.array(children)},
+        ~children={
+          React.array(children);
+        },
         (),
       ),
       children,

--- a/src/BsRecharts__PieChart.re
+++ b/src/BsRecharts__PieChart.re
@@ -41,7 +41,9 @@ module Jsx2 = {
         ~onMouseEnter?,
         ~onMouseLeave?,
         ~width?,
-        ~children={React.array(children)},
+        ~children={
+          React.array(children);
+        },
         (),
       ),
       children,

--- a/src/BsRecharts__ResponsiveContainer.re
+++ b/src/BsRecharts__ResponsiveContainer.re
@@ -65,7 +65,9 @@ module Jsx2 = {
         ~minHeight?,
         ~minWidth?,
         ~width?,
-        ~children={React.array(children)},
+        ~children={
+          React.array(children);
+        },
         (),
       ),
       children,

--- a/src/BsRecharts__Scatter.re
+++ b/src/BsRecharts__Scatter.re
@@ -3,7 +3,7 @@
 [@bs.module "recharts"] [@react.component]
 external make:
   (
-    ~legendType: [@bs.string] [
+    ~legendType: [
                    | `line
                    | `square
                    | `rect
@@ -109,7 +109,9 @@ module Jsx2 = {
         ~onMouseDown?,
         ~onMouseMove?,
         ~id?,
-        ~children={React.array(children)},
+        ~children={
+          React.array(children);
+        },
         (),
       ),
       children,

--- a/src/BsRecharts__ScatterChart.re
+++ b/src/BsRecharts__ScatterChart.re
@@ -53,7 +53,9 @@ module Jsx2 = {
         ~onMouseDown?,
         ~onMouseMove?,
         ~width?,
-        ~children={React.array(children)},
+        ~children={
+          React.array(children);
+        },
         (),
       ),
       children,

--- a/src/BsRecharts__Tooltip.re
+++ b/src/BsRecharts__Tooltip.re
@@ -4,6 +4,7 @@
 external make:
   (
     ~active: bool=?,
+    ~allowEscapeViewBox: Js.t({..})=?,
     ~animationBegin: int=?,
     ~animationDuration: int=?,
     ~animationEasing: [@bs.string] [
@@ -16,7 +17,7 @@ external make:
                         =?,
     ~className: string=?,
     ~content: 'content=?,
-    ~coordinate: Js.t({..})=?,
+    ~position: Js.t({..})=?,
     ~cursor: 'cursor=?,
     ~formatter: 'formatter=?,
     ~isAnimationActive: bool=?,
@@ -40,12 +41,13 @@ module Jsx2 = {
   let make =
       (
         ~active=?,
+        ~allowEscapeViewBox=?,
         ~animationBegin=?,
         ~animationDuration=?,
         ~animationEasing=?,
         ~className=?,
         ~content=?,
-        ~coordinate=?,
+        ~position=?,
         ~cursor=?,
         ~formatter=?,
         ~isAnimationActive=?,
@@ -65,12 +67,13 @@ module Jsx2 = {
       make,
       makeProps(
         ~active?,
+        ~allowEscapeViewBox?,
         ~animationBegin?,
         ~animationDuration?,
         ~animationEasing?,
         ~className?,
         ~content?,
-        ~coordinate?,
+        ~position?,
         ~cursor?,
         ~formatter?,
         ~isAnimationActive?,

--- a/src/BsRecharts__XAxis.re
+++ b/src/BsRecharts__XAxis.re
@@ -4,7 +4,7 @@ open BsRecharts__Utils;
 [@bs.module "recharts"] [@react.component]
 external make:
   (
-    ~_type: [@bs.string] [ | `number | `category]=?,
+    ~_type: [ | `number | `category]=?,
     ~allowDataOverflow: bool=?,
     ~allowDecimals: bool=?,
     ~allowDuplicatedCategory: bool=?,
@@ -27,10 +27,10 @@ external make:
     ~onMouseOut: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
     ~onMouseOver: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
     ~onMouseUp: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
-    ~orientation: [@bs.string] [ | `bottom | `top]=?,
+    ~orientation: [ | `bottom | `top]=?,
     ~padding: paddingHorizontal=?,
     ~reversed: bool=?,
-    ~scale: [@bs.string] [
+    ~scale: [
               | `auto
               | `linear
               | `pow

--- a/src/BsRecharts__YAxis.re
+++ b/src/BsRecharts__YAxis.re
@@ -4,7 +4,7 @@ open BsRecharts__Utils;
 [@bs.module "recharts"] [@react.component]
 external make:
   (
-    ~_type: [@bs.string] [ | `number | `category]=?,
+    ~_type: [ | `number | `category]=?,
     ~allowDataOverflow: bool=?,
     ~allowDecimals: bool=?,
     ~allowDuplicatedCategory: bool=?,
@@ -27,10 +27,10 @@ external make:
     ~onMouseOut: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
     ~onMouseOver: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
     ~onMouseUp: (Js.Nullable.t(Js.t({..})), ReactEvent.Mouse.t) => unit=?,
-    ~orientation: [@bs.string] [ | `left | `right]=?,
+    ~orientation: [ | `left | `right]=?,
     ~padding: paddingVertical=?,
     ~reversed: bool=?,
-    ~scale: [@bs.string] [
+    ~scale: [
               | `auto
               | `linear
               | `pow

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,74 +2,12 @@
 # yarn lockfile v1
 
 
-bs-platform@^5.0.6:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.6.tgz#88c13041fb020479800de3d82c680bf971091425"
-  integrity sha512-6Boa2VEcWJp2WJr38L7bp3J929nYha7gDarjxb070jWzgfPJ/WbzjipmSfnu2eqqk1MfjEIpBipbPz6n1NISwA==
-
-"js-tokens@^3.0.0 || ^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
-  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
-
-loose-envify@^1.1.0, loose-envify@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
-  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
-  dependencies:
-    js-tokens "^3.0.0 || ^4.0.0"
-
-object-assign@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
-
-prop-types@^15.6.2:
-  version "15.7.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
-  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
-  dependencies:
-    loose-envify "^1.4.0"
-    object-assign "^4.1.1"
-    react-is "^16.8.1"
-
-react-dom@>=16.8.1:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
-  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.13.6"
-
-react-is@^16.8.1:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
-  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
-
-react@>=16.8.1:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
-  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.13.6"
+bs-platform@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-8.2.0.tgz#f3f4c06d5710a4c782f0ed030b1fe11e74a0a6d7"
+  integrity sha512-quvmUac/ZxGDsT7L5+6RNXrLPvLHkWFownacaqlwVoyAm770bPyupTRU49ALPGk3HpjfD5eE+lpGdOSPtuwJiA==
 
 reason-react@>=0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.7.0.tgz#46a975c321e81cd51310d7b1a02418ca7667b0d6"
-  integrity sha512-czR/f0lY5iyLCki9gwftOFF5Zs40l7ZSFmpGK/Z6hx2jBVeFDmIiXB8bAQW/cO6IvtuEt97OmsYueiuOYG9XjQ==
-  dependencies:
-    react ">=16.8.1"
-    react-dom ">=16.8.1"
-
-scheduler@^0.13.6:
-  version "0.13.6"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
-  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.9.1.tgz#30a887158200b659aa03e2d75ff4cc54dc462bb0"
+  integrity sha512-nlH0O2TDy9KzOLOW+vlEQk4ExHOeciyzFdoLcsmmiit6hx6H5+CVDrwJ+8aiaLT/kqK5xFOjy4PS7PftWz4plA==


### PR DESCRIPTION
Updates the recharts and bs-platform dependencies to the above mentioned versions.

I have noticed that there is an issue with the documentation for the `Tooltip` component which doesn't have a property called `coordinate`, it's called `position` instead. The bindings have been updated to match to that.