### PR TITLE
add strokeLinejoin + strokeLinecap to Line chart

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 5.1.3
+
+- add `strokeLinecap` and `strokeLinejoin` props to Line
+
 ## 5.1.2
 
 - add `shared` prop to `Tooltip`

--- a/src/Line.re
+++ b/src/Line.re
@@ -41,6 +41,8 @@ external make:
     ~strokeWidth: int=?,
     ~strokeOpacity: option(float)=?,
     ~strokeDasharray: string=?,
+    ~strokeLinecap: string=?,
+    ~strokeLinejoin: string=?,
     ~unit: string=?,
     ~xAxisId: string=?,
     ~yAxisId: string=?


### PR DESCRIPTION
These props are only defined in the ts files

https://github.com/recharts/recharts/blob/d50cbeaa70297ee94d9f168c65892fb6aa7b3b80/src/util/svgPropertiesNoEvents.ts#L247